### PR TITLE
feat: support explicit formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Parameters:
 1. `patterns: string[]` _(required)_: any number of glob patterns
 2. `options: FormatlyOptions` _(optional)_:
    - `cwd: string` _(optional)_: working directory, if not `"."`
-   - `formatter: FormatterName` _(optional)_: explicit formatter to use instead of detecting one, supports `"Biome"`, `"deno fmt"`, `"dprint"`, and `"Prettier"`
+   - `formatter: FormatterName` _(optional)_: explicit formatter to use instead of detecting one, supports `"biome"`, `"deno"`, `"dprint"`, and `"prettier"`
 
 Resolves with a `FormatlyReport`, which is either:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Parameters:
 1. `patterns: string[]` _(required)_: any number of glob patterns
 2. `options: FormatlyOptions` _(optional)_:
    - `cwd: string` _(optional)_: working directory, if not `"."`
+   - `formatter: FormatterName` _(optional)_: explicit formatter to use instead of detecting one, supports `"Biome"`, `"deno fmt"`, `"dprint"`, and `"Prettier"`
 
 Resolves with a `FormatlyReport`, which is either:
 

--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -58,4 +58,18 @@ describe("formatly", () => {
 			result: mockResult,
 		});
 	});
+
+	it("resolves with the result from calling execa when an explicit formatter is passed", async () => {
+		const mockResult = { code: 0, stderr: "", stdout: "🧹" };
+		const mockFormatter = formatters[0];
+		mockExeca.mockResolvedValueOnce(mockResult);
+
+		const report = await formatly(patterns, { formatter: mockFormatter.name });
+
+		expect(report).toEqual({
+			formatter: mockFormatter,
+			ran: true,
+			result: mockResult,
+		});
+	});
 });

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -1,10 +1,14 @@
 import { execa, Result } from "execa";
 
-import { Formatter } from "./formatters.js";
+import { Formatter, FormatterName, formatters } from "./formatters.js";
 import { resolveFormatter } from "./resolveFormatter.js";
 
 export interface FormatlyOptions {
 	cwd?: string;
+	/**
+	 * Pass an explicitly formatter to use instead of automatically detecting
+	 */
+	formatter?: FormatterName;
 }
 
 export type FormatlyReport = FormatlyReportError | FormatlyReportResult;
@@ -22,7 +26,7 @@ export interface FormatlyReportResult {
 
 export async function formatly(
 	patterns: string[],
-	{ cwd }: FormatlyOptions = {},
+	options: FormatlyOptions = {},
 ): Promise<FormatlyReport> {
 	if (!patterns.join("").trim()) {
 		return {
@@ -31,7 +35,9 @@ export async function formatly(
 		};
 	}
 
-	const formatter = await resolveFormatter(cwd);
+	const formatter = options.formatter
+		? formatters.find((f) => f.name === options.formatter)
+		: await resolveFormatter(options.cwd);
 
 	if (!formatter) {
 		return { message: "Could not detect a reporter.", ran: false };

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -5,6 +5,7 @@ import { resolveFormatter } from "./resolveFormatter.js";
 
 export interface FormatlyOptions {
 	cwd?: string;
+
 	/**
 	 * Pass an explicitly formatter to use instead of automatically detecting
 	 */

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -8,11 +8,11 @@ export interface Formatter {
 	};
 }
 
-export type FormatterName = "Biome" | "deno fmt" | "dprint" | "Prettier";
+export type FormatterName = "biome" | "deno" | "dprint" | "prettier";
 
 export const formatters = [
 	{
-		name: "Biome",
+		name: "biome",
 		runner: "npx @biomejs/biome format --write",
 		testers: {
 			configFile: /biome\.json/,
@@ -20,7 +20,7 @@ export const formatters = [
 		},
 	},
 	{
-		name: "deno fmt",
+		name: "deno",
 		runner: "deno fmt",
 		testers: {
 			configFile: /deno\.json/,
@@ -36,7 +36,7 @@ export const formatters = [
 		},
 	},
 	{
-		name: "Prettier",
+		name: "prettier",
 		runner: "npx prettier --write",
 		testers: {
 			configFile: /prettier(?:rc|\.)/,

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,5 +1,3 @@
-export type FormatterName = "Biome" | "deno fmt" | "dprint" | "Prettier";
-
 export interface Formatter {
 	name: FormatterName;
 	runner: string;
@@ -9,6 +7,8 @@ export interface Formatter {
 		script: RegExp;
 	};
 }
+
+export type FormatterName = "Biome" | "deno fmt" | "dprint" | "Prettier";
 
 export const formatters = [
 	{

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,5 +1,7 @@
+export type FormatterName = "Biome" | "deno fmt" | "dprint" | "Prettier";
+
 export interface Formatter {
-	name: string;
+	name: FormatterName;
 	runner: string;
 	testers: {
 		configFile: RegExp;

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -22,11 +22,11 @@ vi.mock("read-package-up", () => ({
 describe("resolveFormatter", () => {
 	describe("from config file", () => {
 		it.each([
-			["Biome", "biome.json", [".git", "biome.json", "src"]],
-			["deno fmt", "deno.json", [".git", "deno.json", "src"]],
+			["biome", "biome.json", [".git", "biome.json", "src"]],
+			["deno", "deno.json", [".git", "deno.json", "src"]],
 			["dprint", "dprint.json", [".git", "dprint.json", "src"]],
-			["Prettier", ".prettierrc", [".git", ".prettierrc", "src"]],
-			["Prettier", "prettier.config.js", [".git", ".prettierrc", "src"]],
+			["prettier", ".prettierrc", [".git", ".prettierrc", "src"]],
+			["prettier", "prettier.config.js", [".git", ".prettierrc", "src"]],
 		])(
 			"resolves with %s when %s exist(s)",
 			async (formatterName, _, children) => {
@@ -52,10 +52,10 @@ describe("resolveFormatter", () => {
 		});
 
 		it.each([
-			["Biome", "biome format"],
-			["deno fmt", "deno fmt"],
+			["biome", "biome format"],
+			["deno", "deno fmt"],
 			["dprint", "dprint"],
-			["Prettier", "prettier"],
+			["prettier", "prettier"],
 		])(
 			"resolves with %s when %s exists in a script",
 			async (formatterName, scriptValue) => {
@@ -76,7 +76,7 @@ describe("resolveFormatter", () => {
 			},
 		);
 
-		it.each([["Prettier", "prettier"]])(
+		it.each([["prettier", "prettier"]])(
 			"resolves with %s when %s exists as a key",
 			async (formatterName, key) => {
 				mockReaddir.mockResolvedValueOnce([]);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #73
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I'd like to be able to reuse `formatly` with an explicit formatter instead of detecting. This options helps for cases where a top-level tooling allows users to explicitly specify the formatter instead of auto-detecting.

I think it'd be nice to also rename the accepted names to `"biome"`, `"deno"`, `"dprint"`, and `"prettier"` to simplify the casing and spacing, but I'd like to get thoughts on this first before making the breaking change.