### PR TITLE
fix: switch from read-package-up to fd-package-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
-		"read-package-up": "^11.0.0"
+		"fd-package-json": "^1.2.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      read-package-up:
-        specifier: ^11.0.0
-        version: 11.0.0
+      fd-package-json:
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.4.1
@@ -2143,6 +2143,9 @@ packages:
   fastq@1.18.0:
     resolution: {integrity: sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==}
 
+  fd-package-json@1.2.0:
+    resolution: {integrity: sha512-45LSPmWf+gC5tdCQMNH4s9Sr00bIkiD9aN7dc5hqkrEw1geRYyDQS1v1oMHAW3ysfxfndqGsrDREHHjNNbKUfA==}
+
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
     peerDependencies:
@@ -2167,8 +2170,8 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-up-simple@1.0.0:
-    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
   find-up@5.0.0:
@@ -3953,6 +3956,9 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  walk-up-path@3.0.1:
+    resolution: {integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -6231,6 +6237,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fd-package-json@1.2.0:
+    dependencies:
+      walk-up-path: 3.0.1
+
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
@@ -6251,7 +6261,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-up-simple@1.0.0: {}
+  find-up-simple@1.0.1: {}
 
   find-up@5.0.0:
     dependencies:
@@ -7533,7 +7543,7 @@ snapshots:
 
   read-package-up@11.0.0:
     dependencies:
-      find-up-simple: 1.0.0
+      find-up-simple: 1.0.1
       read-pkg: 9.0.1
       type-fest: 4.31.0
 
@@ -8148,6 +8158,8 @@ snapshots:
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-uri@3.1.0: {}
+
+  walk-up-path@3.0.1: {}
 
   wcwidth@1.0.1:
     dependencies:

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -11,11 +11,11 @@ vi.mock("node:fs/promises", () => ({
 	},
 }));
 
-const mockReadPackageUp = vi.fn();
+const mockFindPackage = vi.fn();
 
-vi.mock("read-package-up", () => ({
-	get readPackageUp() {
-		return mockReadPackageUp;
+vi.mock("fd-package-json", () => ({
+	get findPackage() {
+		return mockFindPackage;
 	},
 }));
 
@@ -44,7 +44,7 @@ describe("resolveFormatter", () => {
 	describe("from package.json", () => {
 		it("resolves with undefined when no config file matches and a package.json cannot be found", async () => {
 			mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
-			mockReadPackageUp.mockResolvedValueOnce(undefined);
+			mockFindPackage.mockResolvedValueOnce(undefined);
 
 			const formatter = await resolveFormatter();
 
@@ -60,11 +60,9 @@ describe("resolveFormatter", () => {
 			"resolves with %s when %s exists in a script",
 			async (formatterName, scriptValue) => {
 				mockReaddir.mockResolvedValueOnce([]);
-				mockReadPackageUp.mockResolvedValueOnce({
-					packageJson: {
-						scripts: {
-							script: scriptValue,
-						},
+				mockFindPackage.mockResolvedValueOnce({
+					scripts: {
+						script: scriptValue,
 					},
 				});
 
@@ -80,10 +78,8 @@ describe("resolveFormatter", () => {
 			"resolves with %s when %s exists as a key",
 			async (formatterName, key) => {
 				mockReaddir.mockResolvedValueOnce([]);
-				mockReadPackageUp.mockResolvedValueOnce({
-					packageJson: {
-						[key]: {},
-					},
+				mockFindPackage.mockResolvedValueOnce({
+					[key]: {},
 				});
 
 				const formatter = await resolveFormatter();
@@ -97,11 +93,9 @@ describe("resolveFormatter", () => {
 
 	it("resolves with undefined when no config file, scripts, or package keys matched", async () => {
 		mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
-		mockReadPackageUp.mockResolvedValueOnce({
-			packageJson: {
-				otherKey: true,
-				scripts: { totally: "unrelated" },
-			},
+		mockFindPackage.mockResolvedValueOnce({
+			otherKey: true,
+			scripts: { totally: "unrelated" },
 		});
 
 		const formatter = await resolveFormatter();

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -1,5 +1,5 @@
+import { findPackage } from "fd-package-json";
 import * as fs from "node:fs/promises";
-import { readPackageUp } from "read-package-up";
 
 import { Formatter, formatters } from "./formatters.js";
 
@@ -16,16 +16,16 @@ export async function resolveFormatter(
 		}
 	}
 
-	const packageData = await readPackageUp({ cwd });
+	const packageData = await findPackage(cwd);
 	if (!packageData) {
 		return undefined;
 	}
 
-	const { scripts = {}, ...otherKeys } = packageData.packageJson;
+	const { scripts = {}, ...otherKeys } = packageData;
 
-	for (const script of Object.values(scripts)) {
+	for (const script of Object.values(scripts as object)) {
 		for (const formatter of formatters) {
-			if (formatter.testers.script.test(script)) {
+			if (formatter.testers.script.test(script as string)) {
 				return formatter;
 			}
 		}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #98
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

[`fd-package-json`](https://www.npmjs.com/package/fd-package-json) is a lot smaller than [`read-package-up`](https://www.npmjs.com/package/read-package-up). It doesn't include some validation utilities we don't need here.

🧼 