### PR TITLE
feat: support order in resolveFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ console.log(formatter);
 Parameters:
 
 1. `cwd: string` _(optional)_: working directory, if not `"."`
+2. `order: FormatterName[]` _(optional)_: explicit order of formatters to check, defaults to `["biome", "deno", "dprint", "prettier"]`. This can be set to prefer a specific formatter over others, or to skip a formatter entirely.
 
 Resolves with either:
 
@@ -144,7 +145,7 @@ Resolves with either:
 Formatters are detected based on the first match from, in order:
 
 1. Existence of the formatter's default supported config file name
-2. The formatter's name in a `package.json` `fmt` or `format` script
+2. The formatter's name in a `package.json` `"scripts"` value
 3. Well-known root-level `package.json` key
 
 ### Supported Formatters

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -102,4 +102,39 @@ describe("resolveFormatter", () => {
 
 		expect(formatter).toBeUndefined();
 	});
+
+	it("resolves with a default order", async () => {
+		mockReaddir.mockResolvedValueOnce([
+			".git",
+			"biome.json",
+			".prettierrc",
+			"src",
+		]);
+
+		const formatter = await resolveFormatter();
+
+		// default prefers biome over prettier
+		expect(formatter).toBe(
+			formatters.find((formatter) => formatter.name === "biome"),
+		);
+	});
+
+	it("resolves with a custom order", async () => {
+		mockReaddir.mockResolvedValueOnce([
+			".git",
+			"biome.json",
+			".prettierrc",
+			"src",
+		]);
+
+		const formatter = await resolveFormatter(undefined, [
+			"deno",
+			"prettier",
+			"biome",
+		]);
+
+		expect(formatter).toBe(
+			formatters.find((formatter) => formatter.name === "prettier"),
+		);
+	});
 });

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -1,18 +1,24 @@
 import { findPackage } from "fd-package-json";
 import * as fs from "node:fs/promises";
 
-import { Formatter, formatters } from "./formatters.js";
+import { Formatter, FormatterName, formatters } from "./formatters.js";
 
 export async function resolveFormatter(
 	cwd = ".",
+	order?: FormatterName[],
 ): Promise<Formatter | undefined> {
+	const orderredFormatters =
+		order == null
+			? formatters
+			: (order
+					.map((name) => formatters.find((f) => f.name === name))
+					.filter(Boolean) as typeof formatters);
+
 	const children = await fs.readdir(cwd);
 
-	for (const child of children) {
-		for (const formatter of formatters) {
-			if (formatter.testers.configFile.test(child)) {
-				return formatter;
-			}
+	for (const formatter of orderredFormatters) {
+		if (children.some((child) => formatter.testers.configFile.test(child))) {
+			return formatter;
 		}
 	}
 
@@ -22,16 +28,15 @@ export async function resolveFormatter(
 	}
 
 	const { scripts = {}, ...otherKeys } = packageData;
+	const scriptValues = Object.values(scripts as Record<string, string>);
 
-	for (const script of Object.values(scripts as object)) {
-		for (const formatter of formatters) {
-			if (formatter.testers.script.test(script as string)) {
-				return formatter;
-			}
+	for (const formatter of orderredFormatters) {
+		if (scriptValues.some((script) => formatter.testers.script.test(script))) {
+			return formatter;
 		}
 	}
 
-	for (const formatter of formatters) {
+	for (const formatter of orderredFormatters) {
 		if (
 			"packageKey" in formatter.testers &&
 			formatter.testers.packageKey in otherKeys


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #113
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Support an `order` parameter for `resolveFormatter`.

NOTE: Previously the behaviour is that for config files, it prefers by file name alphabetically. And for `"scripts"`, it prefers by which formatter was defined first. So technically there isn't a concrete ordering before.

The former isn't a big issue as the default formatters list was also alphabetical, but the latter (`"scripts"`) I had to change in this PR to search by formatter ordering rather than `"scripts"` values ordering. This could be a breaking change depending on how we treat it, but I think it makes the detection more predictable.
