### PR TITLE
chore: skip checkout in CTA action before transition step

### DIFF
--- a/.github/workflows/cta.yml
+++ b/.github/workflows/cta.yml
@@ -3,16 +3,17 @@ jobs:
     name: Transition
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - id: checkout
+        if: (github.actor == 'JoshuaKGoldberg' || github.actor == 'renovate[bot]') && startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'create-typescript-app')
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           token: ${{ secrets.ACCESS_TOKEN }}
-      - id: check
-        if: (github.actor == 'JoshuaKGoldberg' || github.actor == 'renovate[bot]') && startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'create-typescript-app')
+      - if: steps.checkout.outcome != 'skipped'
         uses: ./.github/actions/transition
-      - if: steps.check.outcome == 'skipped'
+      - if: steps.checkout.outcome == 'skipped'
         run: echo 'Skipping transition mode because the PR does not appear to be an automated or owner-created update to create-typescript-app.'
 
 name: CTA


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #121
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously, the action would only check on step 2 of 3 `if` it should skip. But step 1 -checkout- requires a token that doesn't exist on fork.

Now, step 1 does the `if`. No more checking out the repo unnecessarily.

🧼 