### PR TITLE
fix: add `fmt` to dprint command

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -29,7 +29,7 @@ export const formatters = [
 	},
 	{
 		name: "dprint",
-		runner: "npx dprint",
+		runner: "npx dprint fmt",
 		testers: {
 			configFile: /dprint\.json/,
 			script: /dprint/,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to formatly! 🧼
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #126, fixes #125
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR adds the `fmt` sub command to the existing `npx dprint` command.
