### PR TITLE
fix: respect `options.cwd` when running formatter

### DIFF
--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -77,4 +77,20 @@ describe("formatly", () => {
 			result: { code: 0, signal: null },
 		});
 	});
+
+	it("uses provided cwd to resolve formatter and spawn process", async () => {
+		const cwd = "custom";
+		const mockFormatter = formatters[0];
+		mockResolveFormatter.mockResolvedValueOnce(mockFormatter);
+
+		await formatly(patterns, { cwd });
+
+		expect(mockResolveFormatter).toHaveBeenCalledWith(cwd);
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"npx",
+			["@biomejs/biome", "format", "--write", ...patterns],
+			{ cwd },
+		);
+	});
 });

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -41,9 +41,11 @@ export async function formatly(
 		};
 	}
 
+	const { cwd = process.cwd() } = options;
+
 	const formatter = options.formatter
 		? formatters.find((f) => f.name === options.formatter)
-		: await resolveFormatter(options.cwd);
+		: await resolveFormatter(cwd);
 
 	if (!formatter) {
 		return { message: "Could not detect a reporter.", ran: false };
@@ -55,9 +57,7 @@ export async function formatly(
 		formatter,
 		ran: true,
 		result: await new Promise((resolve, reject) => {
-			const child = spawn(baseCommand, [...args, ...patterns], {
-				cwd: options.cwd ?? process.cwd(),
-			});
+			const child = spawn(baseCommand, [...args, ...patterns], { cwd });
 
 			child.on("error", reject);
 			child.on("exit", (code, signal) => {

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -56,7 +56,7 @@ export async function formatly(
 		ran: true,
 		result: await new Promise((resolve, reject) => {
 			const child = spawn(baseCommand, [...args, ...patterns], {
-				cwd: process.cwd(),
+				cwd: options.cwd ?? process.cwd(),
 			});
 
 			child.on("error", reject);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { formatly } from "./formatly.js";
+import { formatters } from "./formatters.js";
+
+const mockSpawn = vi.fn(() => ({
+	on: (
+		name: string,
+		cb: (code: null | number, signal: NodeJS.Signals | null) => void,
+	) => {
+		if (name === "exit") {
+			cb(0, null);
+		}
+	},
+}));
+
+vi.mock("node:child_process", () => ({
+	get spawn() {
+		return mockSpawn;
+	},
+}));
+
+const mockReaddir = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+	get readdir() {
+		return mockReaddir;
+	},
+}));
+
+const patterns = ["*"];
+
+describe("formatly + resolveFormatter", () => {
+	it("detects formatter in provided cwd and runs formatter in that cwd", async () => {
+		mockReaddir.mockResolvedValueOnce(["deno.json"]);
+
+		const cwd = "custom";
+
+		const report = await formatly(patterns, { cwd });
+
+		expect(report).toEqual({
+			formatter: formatters[1],
+			ran: true,
+			result: { code: 0, signal: null },
+		});
+
+		expect(mockSpawn).toHaveBeenCalledWith("deno", ["fmt", ...patterns], {
+			cwd,
+		});
+	});
+});

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -32,7 +32,7 @@ describe("resolveFormatter", () => {
 			async (formatterName, _, children) => {
 				mockReaddir.mockResolvedValueOnce(children);
 
-				const formatter = await resolveFormatter();
+				const formatter = await resolveFormatter(".");
 
 				expect(formatter).toBe(
 					formatters.find((formatter) => formatter.name === formatterName),
@@ -46,7 +46,7 @@ describe("resolveFormatter", () => {
 			mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
 			mockFindPackage.mockResolvedValueOnce(undefined);
 
-			const formatter = await resolveFormatter();
+			const formatter = await resolveFormatter(".");
 
 			expect(formatter).toBeUndefined();
 		});
@@ -66,7 +66,7 @@ describe("resolveFormatter", () => {
 					},
 				});
 
-				const formatter = await resolveFormatter();
+				const formatter = await resolveFormatter(".");
 
 				expect(formatter).toBe(
 					formatters.find((formatter) => formatter.name === formatterName),
@@ -82,7 +82,7 @@ describe("resolveFormatter", () => {
 					[key]: {},
 				});
 
-				const formatter = await resolveFormatter();
+				const formatter = await resolveFormatter(".");
 
 				expect(formatter).toBe(
 					formatters.find((formatter) => formatter.name === formatterName),
@@ -98,7 +98,7 @@ describe("resolveFormatter", () => {
 			scripts: { totally: "unrelated" },
 		});
 
-		const formatter = await resolveFormatter();
+		const formatter = await resolveFormatter(".");
 
 		expect(formatter).toBeUndefined();
 	});

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -20,6 +20,29 @@ vi.mock("fd-package-json", () => ({
 }));
 
 describe("resolveFormatter", () => {
+	describe("cwd", () => {
+		it("defaults cwd to . when not provided", async () => {
+			mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce(undefined);
+
+			await resolveFormatter();
+
+			expect(mockReaddir).toHaveBeenCalledWith(".");
+			expect(mockFindPackage).toHaveBeenCalledWith(".");
+		});
+
+		it("uses the cwd when provided", async () => {
+			const cwd = "some/other/path";
+			mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce(undefined);
+
+			await resolveFormatter(cwd);
+
+			expect(mockReaddir).toHaveBeenCalledWith(cwd);
+			expect(mockFindPackage).toHaveBeenCalledWith(cwd);
+		});
+	});
+
 	describe("from config file", () => {
 		it.each([
 			["biome", "biome.json", [".git", "biome.json", "src"]],
@@ -32,7 +55,7 @@ describe("resolveFormatter", () => {
 			async (formatterName, _, children) => {
 				mockReaddir.mockResolvedValueOnce(children);
 
-				const formatter = await resolveFormatter(".");
+				const formatter = await resolveFormatter();
 
 				expect(formatter).toBe(
 					formatters.find((formatter) => formatter.name === formatterName),
@@ -46,7 +69,7 @@ describe("resolveFormatter", () => {
 			mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
 			mockFindPackage.mockResolvedValueOnce(undefined);
 
-			const formatter = await resolveFormatter(".");
+			const formatter = await resolveFormatter();
 
 			expect(formatter).toBeUndefined();
 		});
@@ -66,7 +89,7 @@ describe("resolveFormatter", () => {
 					},
 				});
 
-				const formatter = await resolveFormatter(".");
+				const formatter = await resolveFormatter();
 
 				expect(formatter).toBe(
 					formatters.find((formatter) => formatter.name === formatterName),
@@ -82,7 +105,7 @@ describe("resolveFormatter", () => {
 					[key]: {},
 				});
 
-				const formatter = await resolveFormatter(".");
+				const formatter = await resolveFormatter();
 
 				expect(formatter).toBe(
 					formatters.find((formatter) => formatter.name === formatterName),
@@ -98,7 +121,7 @@ describe("resolveFormatter", () => {
 			scripts: { totally: "unrelated" },
 		});
 
-		const formatter = await resolveFormatter(".");
+		const formatter = await resolveFormatter();
 
 		expect(formatter).toBeUndefined();
 	});

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs/promises";
 import { Formatter, formatters } from "./formatters.js";
 
 export async function resolveFormatter(
-	cwd: string,
+	cwd = ".",
 ): Promise<Formatter | undefined> {
 	const children = await fs.readdir(cwd);
 

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs/promises";
 import { Formatter, formatters } from "./formatters.js";
 
 export async function resolveFormatter(
-	cwd = ".",
+	cwd: string,
 ): Promise<Formatter | undefined> {
 	const children = await fs.readdir(cwd);
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to formatly! 🧼
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #130
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Respect `options.cwd` when spawning the formatter process, and fall back to `process.cwd()` if it isn't set.
