### PR TITLE
feat: use Prettier's CLI function in-memory if possible

### DIFF
--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { formatly } from "./formatly.js";
-import { formatters } from "./formatters.js";
+import { formatters } from "./formatters/all.js";
 
 const mockSpawn = vi.fn(() => ({
 	on: (
@@ -62,7 +62,11 @@ describe("formatly", () => {
 		expect(report).toEqual({
 			formatter: mockFormatter,
 			ran: true,
-			result: { code: 0, signal: null },
+			result: {
+				code: 0,
+				runner: "child_process",
+				signal: null,
+			},
 		});
 	});
 
@@ -74,7 +78,11 @@ describe("formatly", () => {
 		expect(report).toEqual({
 			formatter: mockFormatter,
 			ran: true,
-			result: { code: 0, signal: null },
+			result: {
+				code: 0,
+				runner: "child_process",
+				signal: null,
+			},
 		});
 	});
 

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -1,34 +1,6 @@
-import { spawn } from "node:child_process";
-
-import { Formatter, FormatterName, formatters } from "./formatters.js";
+import { formatters } from "./formatters/all.js";
 import { resolveFormatter } from "./resolveFormatter.js";
-
-export interface FormatlyOptions {
-	cwd?: string;
-
-	/**
-	 * Pass an explicitly formatter to use instead of automatically detecting
-	 */
-	formatter?: FormatterName;
-}
-
-export type FormatlyReport = FormatlyReportError | FormatlyReportResult;
-
-export interface FormatlyReportChildProcessResult {
-	code: null | number;
-	signal: NodeJS.Signals | null;
-}
-
-export interface FormatlyReportError {
-	message: string;
-	ran: false;
-}
-
-export interface FormatlyReportResult {
-	formatter: Formatter;
-	ran: true;
-	result: FormatlyReportChildProcessResult;
-}
+import { FormatlyOptions, FormatlyReport } from "./types.js";
 
 export async function formatly(
 	patterns: string[],
@@ -51,18 +23,9 @@ export async function formatly(
 		return { message: "Could not detect a reporter.", ran: false };
 	}
 
-	const [baseCommand, ...args] = formatter.runner.split(" ");
-
 	return {
 		formatter,
 		ran: true,
-		result: await new Promise((resolve, reject) => {
-			const child = spawn(baseCommand, [...args, ...patterns], { cwd });
-
-			child.on("error", reject);
-			child.on("exit", (code, signal) => {
-				resolve({ code, signal });
-			});
-		}),
+		result: await formatter.runner({ cwd, patterns }),
 	};
 }

--- a/src/formatters/all.ts
+++ b/src/formatters/all.ts
@@ -1,19 +1,11 @@
-export interface Formatter {
-	name: FormatterName;
-	runner: string;
-	testers: {
-		configFile: RegExp;
-		packageKey?: string;
-		script: RegExp;
-	};
-}
-
-export type FormatterName = "biome" | "deno" | "dprint" | "prettier";
+import { Formatter } from "../types.js";
+import { createRunCommand } from "./createRunCommand.js";
+import { runPrettier } from "./runPrettier.js";
 
 export const formatters = [
 	{
 		name: "biome",
-		runner: "npx @biomejs/biome format --write",
+		runner: createRunCommand("npx @biomejs/biome format --write"),
 		testers: {
 			configFile: /biome\.json/,
 			script: /biome\s+format/,
@@ -21,7 +13,7 @@ export const formatters = [
 	},
 	{
 		name: "deno",
-		runner: "deno fmt",
+		runner: createRunCommand("deno fmt"),
 		testers: {
 			configFile: /deno\.json/,
 			script: /deno/,
@@ -29,7 +21,7 @@ export const formatters = [
 	},
 	{
 		name: "dprint",
-		runner: "npx dprint fmt",
+		runner: createRunCommand("npx dprint fmt"),
 		testers: {
 			configFile: /dprint\.json/,
 			script: /dprint/,
@@ -37,7 +29,7 @@ export const formatters = [
 	},
 	{
 		name: "prettier",
-		runner: "npx prettier --write",
+		runner: runPrettier,
 		testers: {
 			configFile: /prettier(?:rc|\.)/,
 			packageKey: "prettier",

--- a/src/formatters/createRunCommand.ts
+++ b/src/formatters/createRunCommand.ts
@@ -1,0 +1,6 @@
+import { FormatterRunner } from "../types.js";
+import { runFormatterCommand } from "./runFormatterCommand.js";
+
+export function createRunCommand(runner: string): FormatterRunner {
+	return async (options) => await runFormatterCommand(runner, options);
+}

--- a/src/formatters/runFormatterCommand.ts
+++ b/src/formatters/runFormatterCommand.ts
@@ -1,0 +1,26 @@
+import { spawn } from "child_process";
+
+import {
+	FormatlyReportChildProcessResult,
+	FormatterRunnerOptions,
+} from "../types.js";
+
+export async function runFormatterCommand(
+	runner: string,
+	{ cwd, patterns }: FormatterRunnerOptions,
+): Promise<FormatlyReportChildProcessResult> {
+	const [baseCommand, ...args] = runner.split(" ");
+
+	return await new Promise((resolve, reject) => {
+		const child = spawn(baseCommand, [...args, ...patterns], { cwd });
+
+		child.on("error", reject);
+		child.on("exit", (code, signal) => {
+			resolve({
+				code,
+				runner: "child_process",
+				signal,
+			});
+		});
+	});
+}

--- a/src/formatters/runPrettier.test.ts
+++ b/src/formatters/runPrettier.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runPrettier } from "./runPrettier.js";
+
+const mockRequire = vi.fn();
+
+vi.mock("node:module", () => ({
+	createRequire: () => mockRequire,
+}));
+
+const mockRunFormatterCommand = vi.fn();
+
+vi.mock("./runFormatterCommand.js", () => ({
+	get runFormatterCommand() {
+		return mockRunFormatterCommand;
+	},
+}));
+
+const options = {
+	cwd: ".",
+	patterns: ["."],
+};
+
+describe("runPrettier", () => {
+	it("formats with the command when requiring the internal CLI module fails", async () => {
+		mockRequire.mockImplementationOnce(() => {
+			throw new Error("Module not found");
+		});
+
+		await runPrettier(options);
+
+		expect(mockRunFormatterCommand).toHaveBeenCalledWith(
+			"npx prettier --write",
+			options,
+		);
+	});
+
+	it("formats with the internal CLI module when requiring it succeeds", async () => {
+		const mockPrettierCli = {
+			run: vi.fn(),
+		};
+		mockRequire.mockReturnValueOnce(mockPrettierCli);
+
+		await runPrettier(options);
+
+		expect(mockRunFormatterCommand).not.toHaveBeenCalled();
+		expect(mockPrettierCli.run).toHaveBeenCalledWith([
+			"--log-level",
+			"silent",
+			"--write",
+			...options.patterns,
+		]);
+	});
+});

--- a/src/formatters/runPrettier.ts
+++ b/src/formatters/runPrettier.ts
@@ -1,0 +1,34 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { FormatterRunner } from "../types.js";
+import { runFormatterCommand } from "./runFormatterCommand.js";
+import { wrapSafe } from "./wrapSafe.js";
+
+/**
+ * @see https://github.com/prettier/prettier/issues/17422
+ * @see https://github.com/prettier/prettier/blob/e7202d63e715728bc891eab0075eddc6194980db/src/cli/index.js#L13
+ */
+interface PrettierInternalCLI {
+	run(rawArguments?: string[]): Promise<void>;
+}
+
+export const runPrettier: FormatterRunner = async ({ cwd, patterns }) => {
+	// We first try to load Prettier's CLI module directly.
+	// It's not in prettier's exports, but CJS require() doesn't respect those.
+	// See https://github.com/prettier/prettier/issues/17422
+	const require = createRequire(path.join(cwd, "index.js"));
+	const prettierCli = wrapSafe(
+		() => require("prettier/internal/cli.mjs") as PrettierInternalCLI,
+	);
+
+	if (!prettierCli) {
+		return await runFormatterCommand("npx prettier --write", { cwd, patterns });
+	}
+
+	await prettierCli.run(["--log-level", "silent", "--write", ...patterns]);
+
+	return {
+		runner: "virtual",
+	};
+};

--- a/src/formatters/wrapSafe.ts
+++ b/src/formatters/wrapSafe.ts
@@ -1,0 +1,7 @@
+export function wrapSafe<T>(task: () => T) {
+	try {
+		return task();
+	} catch {
+		return undefined;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./formatly.js";
-export * from "./formatters.js";
+export * from "./formatters/all.js";
 export * from "./resolveFormatter.js";
+export * from "./types.js";

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { formatly } from "./formatly.js";
-import { formatters } from "./formatters.js";
+import { formatters } from "./formatters/all.js";
 
 const mockSpawn = vi.fn(() => ({
 	on: (
@@ -41,7 +41,7 @@ describe("formatly + resolveFormatter", () => {
 		expect(report).toEqual({
 			formatter: formatters[1],
 			ran: true,
-			result: { code: 0, signal: null },
+			result: { code: 0, runner: "child_process", signal: null },
 		});
 
 		expect(mockSpawn).toHaveBeenCalledWith("deno", ["fmt", ...patterns], {

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { formatters } from "./formatters.js";
+import { formatters } from "./formatters/all.js";
 import { resolveFormatter } from "./resolveFormatter.js";
 
 const mockReaddir = vi.fn();

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -1,7 +1,8 @@
 import { findPackage } from "fd-package-json";
 import * as fs from "node:fs/promises";
 
-import { Formatter, formatters } from "./formatters.js";
+import { formatters } from "./formatters/all.js";
+import { Formatter } from "./types.js";
 
 export async function resolveFormatter(
 	cwd = ".",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,52 @@
+export interface FormatlyOptions {
+	cwd?: string;
+
+	/**
+	 * Pass an explicitly formatter to use instead of automatically detecting
+	 */
+	formatter?: FormatterName;
+}
+
+export type FormatlyReport = FormatlyReportError | FormatlyReportResult;
+
+export interface FormatlyReportChildProcessResult {
+	code: null | number;
+	runner: "child_process";
+	signal: NodeJS.Signals | null;
+}
+
+export interface FormatlyReportError {
+	message: string;
+	ran: false;
+}
+
+export interface FormatlyReportResult {
+	formatter: Formatter;
+	ran: true;
+	result: FormatlyReportChildProcessResult | FormatlyReportVirtualResult;
+}
+
+export interface FormatlyReportVirtualResult {
+	runner: "virtual";
+}
+
+export interface Formatter {
+	name: FormatterName;
+	runner: FormatterRunner;
+	testers: {
+		configFile: RegExp;
+		packageKey?: string;
+		script: RegExp;
+	};
+}
+
+export type FormatterName = "biome" | "deno" | "dprint" | "prettier";
+
+export type FormatterRunner = (
+	options: FormatterRunnerOptions,
+) => Promise<FormatlyReportChildProcessResult | FormatlyReportVirtualResult>;
+
+export interface FormatterRunnerOptions {
+	cwd: string;
+	patterns: string[];
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #114
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Augments the built-in Prettier formatter by making its runner a function that attempts to `require()` Prettier's internal CLI `run` function. This is very hacky and unfortunate but I couldn't find another way to run in-memory. Filed: https://github.com/prettier/prettier/issues/17422

The change ended up needing a bit more refactoring than I thought:

* Formatter runners are now each a function:
  * Most use `createRunCommand()` -> `runFormatterCommand()` to run a single CLI command
  * Prettier has its own `runPrettier` that falls back to `runFormatterCommand()` if needed
* Types are all extracted to a root-level `types.ts` file to avoid circular dependencies

🧼 