### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.3

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ Userland projects still need to configure a formatter themselves.
 See [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md), then [`.github/DEVELOPMENT.md`](./.github/DEVELOPMENT.md).
 Thanks! 🧼
 
+## Used by
+
+<a href="https://dependents.info/JoshuaKGoldberg/formatly" target="_blank">
+  <img src="https://dependents.info/JoshuaKGoldberg/formatly/image" alt="Network Dependents" />
+</a>
+
 ## Contributors
 
 <!-- spellchecker: disable -->


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="698" alt="image" src="https://github.com/user-attachments/assets/be58753f-b6f6-4343-8192-8078dac6b6bf" />

Please feel free to close the PR if you don't want to have this!