### PR TITLE
feat: add oxfmt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Formatters are detected based on the first match from, in order:
 | [Biome](https://biomejs.dev/formatter)                      | [Configure Biome](https://biomejs.dev/guides/configure-biome)                                           |              | `biome`    |
 | [deno fmt](https://docs.deno.com/runtime/reference/cli/fmt) | [Deno Configuration > Formatting](https://docs.deno.com/runtime/fundamentals/configuration/#formatting) |              | `deno`     |
 | [dprint](https://dprint.dev)                                | [dprint setup](https://dprint.dev/setup)                                                                |              | `dprint`   |
+| [Oxfmt](https://oxc.rs/docs/guide/usage/formatter)          | [Oxfmt Configuration](https://oxc.rs/docs/guide/usage/formatter/config.html)                            |              | `oxfmt`    |
 | [Prettier](https://prettier.io)                             | [Prettier Configuration File](https://prettier.io/docs/en/configuration)                                | `"prettier"` | `prettier` |
 
 > Want support for a formatter not mentioned here?

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
 		"formatly",
 		"joshuakgoldberg",
 		"markdownlintignore",
+		"oxfmtrc",
 		"packageData",
 		"public",
 		"repository",

--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -86,6 +86,16 @@ describe("formatly", () => {
 		});
 	});
 
+	it("runs oxfmt with npx", async () => {
+		const formatter = "oxfmt";
+
+		await formatly(patterns, { formatter });
+
+		expect(mockSpawn).toHaveBeenCalledWith("npx", [formatter, ...patterns], {
+			cwd: process.cwd(),
+		});
+	});
+
 	it("uses provided cwd to resolve formatter and spawn process", async () => {
 		const cwd = "custom";
 		const mockFormatter = formatters[0];

--- a/src/formatters/all.ts
+++ b/src/formatters/all.ts
@@ -28,6 +28,14 @@ export const formatters = [
 		},
 	},
 	{
+		name: "oxfmt",
+		runner: createRunCommand("npx oxfmt"),
+		testers: {
+			configFile: /^(?:\.oxfmtrc\.(?:json|jsonc)|oxfmt\.config\.(?:mts|ts))$/,
+			script: /oxfmt/,
+		},
+	},
+	{
 		name: "prettier",
 		runner: runPrettier,
 		testers: {

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -48,6 +48,10 @@ describe("resolveFormatter", () => {
 			["biome", "biome.json", [".git", "biome.json", "src"]],
 			["deno", "deno.json", [".git", "deno.json", "src"]],
 			["dprint", "dprint.json", [".git", "dprint.json", "src"]],
+			["oxfmt", ".oxfmtrc.json", [".git", ".oxfmtrc.json", "src"]],
+			["oxfmt", ".oxfmtrc.jsonc", [".git", ".oxfmtrc.jsonc", "src"]],
+			["oxfmt", "oxfmt.config.ts", [".git", "oxfmt.config.ts", "src"]],
+			["oxfmt", "oxfmt.config.mts", [".git", "oxfmt.config.mts", "src"]],
 			["prettier", ".prettierrc", [".git", ".prettierrc", "src"]],
 			["prettier", "prettier.config.js", [".git", ".prettierrc", "src"]],
 		])(
@@ -78,6 +82,7 @@ describe("resolveFormatter", () => {
 			["biome", "biome format"],
 			["deno", "deno fmt"],
 			["dprint", "dprint"],
+			["oxfmt", "oxfmt"],
 			["prettier", "prettier"],
 		])(
 			"resolves with %s when %s exists in a script",

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface Formatter {
 	};
 }
 
-export type FormatterName = "biome" | "deno" | "dprint" | "prettier";
+export type FormatterName = "biome" | "deno" | "dprint" | "oxfmt" | "prettier";
 
 export type FormatterRunner = (
 	options: FormatterRunnerOptions,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #546
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds oxfmt detection from its supported config files and package scripts, allows it as an explicit formatter, runs it through npx, and documents the new formatter with test coverage. 🧼