### PR TITLE
feat: use project package manager to run formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
-		"fd-package-json": "^2.0.0"
+		"fd-package-json": "^2.0.0",
+		"package-manager-detector": "^1.8.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       fd-package-json:
         specifier: ^2.0.0
         version: 2.0.0
+      package-manager-detector:
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.7.0
@@ -3482,6 +3485,9 @@ packages:
     resolution: {integrity: sha512-xS8okscm06Nw2OhInIqFpFhkVWLRYRjCujHN7yeEUHlS+Ppg1n/ec4AkDlycdhUX/98HbAuOfKJ0lLXt6NIV9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -7880,6 +7886,8 @@ snapshots:
       semver: 7.8.5
       validate-npm-package-license: 3.0.4
       yargs: 18.0.0
+
+  package-manager-detector@1.8.0: {}
 
   parent-module@1.0.1:
     dependencies:

--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -96,8 +96,8 @@ describe("formatly", () => {
 		expect(mockResolveFormatter).toHaveBeenCalledWith(cwd);
 
 		expect(mockSpawn).toHaveBeenCalledWith(
-			"npx",
-			["@biomejs/biome", "format", "--write", ...patterns],
+			"pnpm",
+			["exec", "@biomejs/biome", "format", "--write", ...patterns],
 			{ cwd },
 		);
 	});

--- a/src/formatters/all.ts
+++ b/src/formatters/all.ts
@@ -1,11 +1,17 @@
 import { Formatter } from "../types.js";
-import { createRunCommand } from "./createRunCommand.js";
+import {
+	createRunCommand,
+	createRunPackageCommand,
+} from "./createRunCommand.js";
 import { runPrettier } from "./runPrettier.js";
 
 export const formatters = [
 	{
 		name: "biome",
-		runner: createRunCommand("npx @biomejs/biome format --write"),
+		runner: createRunPackageCommand({
+			args: ["format", "--write"],
+			command: "@biomejs/biome",
+		}),
 		testers: {
 			configFile: /biome\.json/,
 			script: /biome\s+format/,
@@ -13,7 +19,10 @@ export const formatters = [
 	},
 	{
 		name: "deno",
-		runner: createRunCommand("deno fmt"),
+		runner: createRunCommand({
+			args: ["fmt"],
+			command: "deno",
+		}),
 		testers: {
 			configFile: /deno\.json/,
 			script: /deno/,
@@ -21,7 +30,10 @@ export const formatters = [
 	},
 	{
 		name: "dprint",
-		runner: createRunCommand("npx dprint fmt"),
+		runner: createRunPackageCommand({
+			args: ["fmt"],
+			command: "dprint",
+		}),
 		testers: {
 			configFile: /dprint\.json/,
 			script: /dprint/,

--- a/src/formatters/createRunCommand.ts
+++ b/src/formatters/createRunCommand.ts
@@ -1,6 +1,17 @@
-import { FormatterRunner } from "../types.js";
-import { runFormatterCommand } from "./runFormatterCommand.js";
+import type { ResolvedCommand } from "package-manager-detector";
 
-export function createRunCommand(runner: string): FormatterRunner {
-	return async (options) => await runFormatterCommand(runner, options);
+import { FormatterRunner } from "../types.js";
+import {
+	runFormatterCommand,
+	runPackageFormatterCommand,
+} from "./runFormatterCommand.js";
+
+export function createRunCommand(command: ResolvedCommand): FormatterRunner {
+	return async (options) => await runFormatterCommand(command, options);
+}
+
+export function createRunPackageCommand(
+	command: ResolvedCommand,
+): FormatterRunner {
+	return async (options) => await runPackageFormatterCommand(command, options);
 }

--- a/src/formatters/runFormatterCommand.test.ts
+++ b/src/formatters/runFormatterCommand.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runFormatterCommand } from "./runFormatterCommand.js";
+
+const mockSpawn = vi.fn(() => ({
+	on: (
+		name: string,
+		callback: (code: null | number, signal: NodeJS.Signals | null) => void,
+	) => {
+		if (name === "exit") {
+			callback(0, null);
+		}
+	},
+}));
+
+vi.mock("node:child_process", () => ({
+	get spawn() {
+		return mockSpawn;
+	},
+}));
+
+const mockDetect = vi.fn();
+
+vi.mock("package-manager-detector", () => ({
+	get detect() {
+		return mockDetect;
+	},
+}));
+
+const options = {
+	cwd: "project",
+	patterns: ["src/**/*.ts"],
+};
+
+describe("runFormatterCommand", () => {
+	it("uses the detected package manager to execute local packages", async () => {
+		mockDetect.mockResolvedValueOnce({
+			agent: "pnpm",
+			name: "pnpm",
+		});
+
+		await runFormatterCommand("npx dprint fmt", options);
+
+		expect(mockDetect).toHaveBeenCalledWith({ cwd: options.cwd });
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"pnpm",
+			["exec", "dprint", "fmt", ...options.patterns],
+			{ cwd: options.cwd },
+		);
+	});
+
+	it("falls back to npx when a package manager cannot be detected", async () => {
+		mockDetect.mockResolvedValueOnce(null);
+
+		await runFormatterCommand("npx dprint fmt", options);
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"npx",
+			["dprint", "fmt", ...options.patterns],
+			{ cwd: options.cwd },
+		);
+	});
+
+	it("runs non-package-manager commands directly", async () => {
+		await runFormatterCommand("deno fmt", options);
+
+		expect(mockDetect).not.toHaveBeenCalled();
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"deno",
+			["fmt", ...options.patterns],
+			{ cwd: options.cwd },
+		);
+	});
+});

--- a/src/formatters/runFormatterCommand.test.ts
+++ b/src/formatters/runFormatterCommand.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { runFormatterCommand } from "./runFormatterCommand.js";
+import {
+	runFormatterCommand,
+	runPackageFormatterCommand,
+} from "./runFormatterCommand.js";
 
 const mockSpawn = vi.fn(() => ({
 	on: (
@@ -39,7 +42,10 @@ describe("runFormatterCommand", () => {
 			name: "pnpm",
 		});
 
-		await runFormatterCommand("npx dprint fmt", options);
+		await runPackageFormatterCommand(
+			{ args: ["fmt"], command: "dprint" },
+			options,
+		);
 
 		expect(mockDetect).toHaveBeenCalledWith({ cwd: options.cwd });
 		expect(mockSpawn).toHaveBeenCalledWith(
@@ -52,7 +58,10 @@ describe("runFormatterCommand", () => {
 	it("falls back to npx when a package manager cannot be detected", async () => {
 		mockDetect.mockResolvedValueOnce(null);
 
-		await runFormatterCommand("npx dprint fmt", options);
+		await runPackageFormatterCommand(
+			{ args: ["fmt"], command: "dprint" },
+			options,
+		);
 
 		expect(mockSpawn).toHaveBeenCalledWith(
 			"npx",
@@ -62,7 +71,7 @@ describe("runFormatterCommand", () => {
 	});
 
 	it("runs non-package-manager commands directly", async () => {
-		await runFormatterCommand("deno fmt", options);
+		await runFormatterCommand({ args: ["fmt"], command: "deno" }, options);
 
 		expect(mockDetect).not.toHaveBeenCalled();
 		expect(mockSpawn).toHaveBeenCalledWith(

--- a/src/formatters/runFormatterCommand.ts
+++ b/src/formatters/runFormatterCommand.ts
@@ -1,4 +1,6 @@
 import { spawn } from "child_process";
+import { detect } from "package-manager-detector";
+import { resolveCommand } from "package-manager-detector/commands";
 
 import {
 	FormatlyReportChildProcessResult,
@@ -10,9 +12,17 @@ export async function runFormatterCommand(
 	{ cwd, patterns }: FormatterRunnerOptions,
 ): Promise<FormatlyReportChildProcessResult> {
 	const [baseCommand, ...args] = runner.split(" ");
+	const command =
+		baseCommand === "npx"
+			? (resolveCommand(
+					(await detect({ cwd }))?.agent ?? "npm",
+					"execute-local",
+					[...args, ...patterns],
+				) ?? { args: [...args, ...patterns], command: baseCommand })
+			: { args: [...args, ...patterns], command: baseCommand };
 
 	return await new Promise((resolve, reject) => {
-		const child = spawn(baseCommand, [...args, ...patterns], { cwd });
+		const child = spawn(command.command, command.args, { cwd });
 
 		child.on("error", reject);
 		child.on("exit", (code, signal) => {

--- a/src/formatters/runFormatterCommand.ts
+++ b/src/formatters/runFormatterCommand.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { detect } from "package-manager-detector";
+import { detect, type ResolvedCommand } from "package-manager-detector";
 import { resolveCommand } from "package-manager-detector/commands";
 
 import {
@@ -8,21 +8,35 @@ import {
 } from "../types.js";
 
 export async function runFormatterCommand(
-	runner: string,
+	{ args, command }: ResolvedCommand,
 	{ cwd, patterns }: FormatterRunnerOptions,
 ): Promise<FormatlyReportChildProcessResult> {
-	const [baseCommand, ...args] = runner.split(" ");
-	const command =
-		baseCommand === "npx"
-			? (resolveCommand(
-					(await detect({ cwd }))?.agent ?? "npm",
-					"execute-local",
-					[...args, ...patterns],
-				) ?? { args: [...args, ...patterns], command: baseCommand })
-			: { args: [...args, ...patterns], command: baseCommand };
+	return await spawnFormatterCommand(
+		{ args: [...args, ...patterns], command },
+		cwd,
+	);
+}
 
+export async function runPackageFormatterCommand(
+	{ args, command }: ResolvedCommand,
+	{ cwd, patterns }: FormatterRunnerOptions,
+): Promise<FormatlyReportChildProcessResult> {
+	const packageArguments = [command, ...args, ...patterns];
+	const resolvedCommand = resolveCommand(
+		(await detect({ cwd }))?.agent ?? "npm",
+		"execute-local",
+		packageArguments,
+	) ?? { args: packageArguments, command: "npx" };
+
+	return await spawnFormatterCommand(resolvedCommand, cwd);
+}
+
+async function spawnFormatterCommand(
+	{ args, command }: ResolvedCommand,
+	cwd: string,
+): Promise<FormatlyReportChildProcessResult> {
 	return await new Promise((resolve, reject) => {
-		const child = spawn(command.command, command.args, { cwd });
+		const child = spawn(command, args, { cwd });
 
 		child.on("error", reject);
 		child.on("exit", (code, signal) => {

--- a/src/formatters/runPrettier.test.ts
+++ b/src/formatters/runPrettier.test.ts
@@ -8,11 +8,11 @@ vi.mock("node:module", () => ({
 	createRequire: () => mockRequire,
 }));
 
-const mockRunFormatterCommand = vi.fn();
+const mockRunPackageFormatterCommand = vi.fn();
 
 vi.mock("./runFormatterCommand.js", () => ({
-	get runFormatterCommand() {
-		return mockRunFormatterCommand;
+	get runPackageFormatterCommand() {
+		return mockRunPackageFormatterCommand;
 	},
 }));
 
@@ -29,8 +29,8 @@ describe("runPrettier", () => {
 
 		await runPrettier(options);
 
-		expect(mockRunFormatterCommand).toHaveBeenCalledWith(
-			"npx prettier --write",
+		expect(mockRunPackageFormatterCommand).toHaveBeenCalledWith(
+			{ args: ["--write"], command: "prettier" },
 			options,
 		);
 	});
@@ -43,7 +43,7 @@ describe("runPrettier", () => {
 
 		await runPrettier(options);
 
-		expect(mockRunFormatterCommand).not.toHaveBeenCalled();
+		expect(mockRunPackageFormatterCommand).not.toHaveBeenCalled();
 		expect(mockPrettierCli.run).toHaveBeenCalledWith([
 			"--log-level",
 			"silent",

--- a/src/formatters/runPrettier.ts
+++ b/src/formatters/runPrettier.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 
 import { FormatterRunner } from "../types.js";
-import { runFormatterCommand } from "./runFormatterCommand.js";
+import { runPackageFormatterCommand } from "./runFormatterCommand.js";
 import { wrapSafe } from "./wrapSafe.js";
 
 /**
@@ -23,7 +23,10 @@ export const runPrettier: FormatterRunner = async ({ cwd, patterns }) => {
 	);
 
 	if (!prettierCli) {
-		return await runFormatterCommand("npx prettier --write", { cwd, patterns });
+		return await runPackageFormatterCommand(
+			{ args: ["--write"], command: "prettier" },
+			{ cwd, patterns },
+		);
 	}
 
 	await prettierCli.run(["--log-level", "silent", "--write", ...patterns]);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #112
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Detects the project package manager and uses its local-execution command for formatter binaries, while retaining npm fallback behavior and direct execution for tools such as Deno. Formatter commands and arguments are represented structurally so execution does not depend on parsing shell command strings.

🧼