### PR TITLE
fix: pass oxfmt to createRunCommand as a resolved command

### DIFF
--- a/src/formatters/all.ts
+++ b/src/formatters/all.ts
@@ -41,7 +41,10 @@ export const formatters = [
 	},
 	{
 		name: "oxfmt",
-		runner: createRunCommand("npx oxfmt"),
+		runner: createRunCommand({
+			args: ["oxfmt"],
+			command: "npx",
+		}),
 		testers: {
 			configFile: /^(?:\.oxfmtrc\.(?:json|jsonc)|oxfmt\.config\.(?:mts|ts))$/,
 			script: /oxfmt/,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #573
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

No existing issue - this is unreported breakage on `main`.

## Overview

`createRunCommand` takes a `ResolvedCommand`, but the `oxfmt` entry added in #544 passes the string `"npx oxfmt"`. That doesn't type check, and at runtime `spawnFormatterCommand` destructures `{ args, command }` off a string, so `args` is `undefined` and spreading it throws `TypeError: args is not iterable`.

🧼