### PR TITLE
feat: add stopDirectory option for parent directory searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Parameters:
 2. `options: FormatlyOptions` _(optional)_:
    - `cwd: string` _(optional)_: working directory, if not `"."`
    - `formatter: FormatterName` _(optional)_: explicit formatter to use instead of detecting one, supports `"biome"`, `"deno"`, `"dprint"`, and `"prettier"`
+   - `stopDirectory: StopDirectory` _(optional)_: directory to stop searching parent directories for a config file at, as used by [`resolveFormatter`](#resolveformatter)
 
 Resolves with a `FormatlyReport`, which is either:
 
@@ -130,6 +131,28 @@ console.log(formatter);
 Parameters:
 
 1. `cwd: string` _(optional)_: working directory, if not `"."`
+2. `options: ResolveFormatterOptions` _(optional)_:
+   - `stopDirectory: StopDirectory` _(optional)_: directory to stop searching parent directories for a config file at, either a `string` path or a `(currentDirectory: string) => boolean` function
+
+By default, only the working directory is searched for a config file.
+Passing `stopDirectory` also searches each parent directory in turn, stopping once the directory matching `stopDirectory` has been searched.
+A `string` is matched as a directory path, while a function is called with each directory and may return `true` to indicate the last directory to search.
+Reaching the file system root without a match throws an error, as that indicates a `stopDirectory` that isn't a parent of the working directory.
+
+For example, to search up to whichever parent directory contains a `.git` directory:
+
+```ts
+import { resolveFormatter } from "formatly";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
+const formatter = await resolveFormatter("path/to/project", {
+	stopDirectory: (currentDirectory) =>
+		existsSync(path.join(currentDirectory, ".git")),
+});
+
+console.log(formatter);
+```
 
 Resolves with either:
 
@@ -146,6 +169,9 @@ Formatters are detected based on the first match from, in order:
 1. Existence of the formatter's default supported config file name
 2. The formatter's name in a `package.json` `fmt` or `format` script
 3. Well-known root-level `package.json` key
+
+Config files are only searched for in the working directory unless a [`stopDirectory`](#resolveformatter) is provided.
+`package.json` is always searched for in the working directory and its parent directories.
 
 ### Supported Formatters
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,10 @@ export default tseslint.config(
 			},
 		},
 		rules: {
+			"@typescript-eslint/no-unnecessary-condition": [
+				"error",
+				{ allowConstantLoopConditions: "only-allowed-literals" },
+			],
 			"n/no-unsupported-features/node-builtins": "off",
 
 			// Stylistic concerns that don't interfere with Prettier

--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -86,6 +86,17 @@ describe("formatly", () => {
 		});
 	});
 
+	it("passes stopDirectory to resolveFormatter when provided", async () => {
+		const stopDirectory = "custom";
+		mockResolveFormatter.mockResolvedValueOnce(formatters[0]);
+
+		await formatly(patterns, { stopDirectory });
+
+		expect(mockResolveFormatter).toHaveBeenCalledWith(process.cwd(), {
+			stopDirectory,
+		});
+	});
+
 	it("runs oxfmt with npx", async () => {
 		const formatter = "oxfmt";
 
@@ -103,7 +114,9 @@ describe("formatly", () => {
 
 		await formatly(patterns, { cwd });
 
-		expect(mockResolveFormatter).toHaveBeenCalledWith(cwd);
+		expect(mockResolveFormatter).toHaveBeenCalledWith(cwd, {
+			stopDirectory: undefined,
+		});
 
 		expect(mockSpawn).toHaveBeenCalledWith(
 			"pnpm",

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -13,11 +13,11 @@ export async function formatly(
 		};
 	}
 
-	const { cwd = process.cwd() } = options;
+	const { cwd = process.cwd(), stopDirectory } = options;
 
 	const formatter = options.formatter
 		? formatters.find((f) => f.name === options.formatter)
-		: await resolveFormatter(cwd);
+		: await resolveFormatter(cwd, { stopDirectory });
 
 	if (!formatter) {
 		return { message: "Could not detect a reporter.", ran: false };

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { formatters } from "./formatters/all.js";
@@ -39,6 +40,123 @@ describe("resolveFormatter", () => {
 			await resolveFormatter(cwd);
 
 			expect(mockReaddir).toHaveBeenCalledWith(cwd);
+			expect(mockFindPackage).toHaveBeenCalledWith(cwd);
+		});
+	});
+
+	describe("stopDirectory", () => {
+		it("searches only the cwd when stopDirectory is not provided", async () => {
+			const cwd = path.join(path.resolve("/"), "repo", "packages", "child");
+			mockReaddir.mockResolvedValueOnce(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce(undefined);
+
+			await resolveFormatter(cwd);
+
+			expect(mockReaddir.mock.calls).toEqual([[cwd]]);
+		});
+
+		it("resolves with a formatter when a parent directory within stopDirectory has a config file", async () => {
+			const stopDirectory = path.join(path.resolve("/"), "repo");
+			const cwd = path.join(stopDirectory, "packages", "child");
+			mockReaddir
+				.mockResolvedValueOnce(["src"])
+				.mockResolvedValueOnce(["child"])
+				.mockResolvedValueOnce([".git", ".prettierrc"]);
+
+			const formatter = await resolveFormatter(cwd, { stopDirectory });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+			expect(mockReaddir.mock.calls).toEqual([
+				[cwd],
+				[path.join(stopDirectory, "packages")],
+				[stopDirectory],
+			]);
+		});
+
+		it("resolves with undefined when no config file exists in any directory up to stopDirectory", async () => {
+			const stopDirectory = path.join(path.resolve("/"), "repo");
+			const cwd = path.join(stopDirectory, "packages", "child");
+			mockReaddir.mockResolvedValue(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce(undefined);
+
+			const formatter = await resolveFormatter(cwd, { stopDirectory });
+
+			expect(formatter).toBeUndefined();
+			expect(mockReaddir.mock.calls).toEqual([
+				[cwd],
+				[path.join(stopDirectory, "packages")],
+				[stopDirectory],
+			]);
+		});
+
+		it("resolves stopDirectory relative to the process working directory when provided a relative path", async () => {
+			const cwd = path.join(process.cwd(), "child");
+			mockReaddir.mockResolvedValue(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce(undefined);
+
+			await resolveFormatter(cwd, { stopDirectory: "." });
+
+			expect(mockReaddir.mock.calls).toEqual([[cwd], [process.cwd()]]);
+		});
+
+		it("stops after the directory matched by stopDirectory when provided a function", async () => {
+			const root = path.join(path.resolve("/"), "repo");
+			const cwd = path.join(root, "packages", "child");
+			mockReaddir.mockResolvedValue(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce(undefined);
+
+			await resolveFormatter(cwd, {
+				stopDirectory: (currentDirectory) =>
+					path.basename(currentDirectory) === "packages",
+			});
+
+			expect(mockReaddir.mock.calls).toEqual([
+				[cwd],
+				[path.join(root, "packages")],
+			]);
+		});
+
+		it("throws an error when the file system root is reached before stopDirectory matches", async () => {
+			const root = path.resolve("/");
+			const cwd = path.join(root, "repo", "child");
+			mockReaddir.mockResolvedValue(["totally", "unrelated"]);
+
+			await expect(
+				resolveFormatter(cwd, { stopDirectory: () => false }),
+			).rejects.toThrow(
+				`Reached the file system root searching up from ${cwd} without matching stopDirectory.`,
+			);
+		});
+
+		it("resolves with a formatter when the file system root has a config file and matches stopDirectory", async () => {
+			const root = path.resolve("/");
+			const cwd = path.join(root, "repo");
+			mockReaddir
+				.mockResolvedValueOnce(["totally", "unrelated"])
+				.mockResolvedValueOnce([".prettierrc"]);
+
+			const formatter = await resolveFormatter(cwd, { stopDirectory: root });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+		});
+
+		it("falls back to the package.json of the cwd when no directory up to stopDirectory has a config file", async () => {
+			const stopDirectory = path.join(path.resolve("/"), "repo");
+			const cwd = path.join(stopDirectory, "packages", "child");
+			mockReaddir.mockResolvedValue(["totally", "unrelated"]);
+			mockFindPackage.mockResolvedValueOnce({
+				scripts: { format: "prettier" },
+			});
+
+			const formatter = await resolveFormatter(cwd, { stopDirectory });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
 			expect(mockFindPackage).toHaveBeenCalledWith(cwd);
 		});
 	});

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -1,18 +1,22 @@
 import { findPackage } from "fd-package-json";
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 
 import { formatters } from "./formatters/all.js";
-import { Formatter } from "./types.js";
+import { Formatter, ResolveFormatterOptions, StopDirectory } from "./types.js";
 
 export async function resolveFormatter(
 	cwd = ".",
+	options: ResolveFormatterOptions = {},
 ): Promise<Formatter | undefined> {
-	const children = await fs.readdir(cwd);
+	for (const directory of walkUpDirectories(cwd, options)) {
+		const children = await fs.readdir(directory);
 
-	for (const child of children) {
-		for (const formatter of formatters) {
-			if (formatter.testers.configFile.test(child)) {
-				return formatter;
+		for (const child of children) {
+			for (const formatter of formatters) {
+				if (formatter.testers.configFile.test(child)) {
+					return formatter;
+				}
 			}
 		}
 	}
@@ -42,4 +46,46 @@ export async function resolveFormatter(
 	}
 
 	return undefined;
+}
+
+function createStopDirectoryMatcher(stopDirectory: StopDirectory) {
+	if (typeof stopDirectory !== "string") {
+		return stopDirectory;
+	}
+
+	const resolved = path.resolve(stopDirectory);
+
+	return (currentDirectory: string) => currentDirectory === resolved;
+}
+
+function* walkUpDirectories(
+	cwd: string,
+	{ stopDirectory }: ResolveFormatterOptions,
+) {
+	if (stopDirectory === undefined) {
+		yield cwd;
+		return;
+	}
+
+	const isStopDirectory = createStopDirectoryMatcher(stopDirectory);
+	let currentDirectory = path.resolve(cwd);
+
+	while (true) {
+		const parentDirectory = path.dirname(currentDirectory);
+		const matched = isStopDirectory(currentDirectory);
+
+		if (!matched && parentDirectory === currentDirectory) {
+			throw new Error(
+				`Reached the file system root searching up from ${path.resolve(cwd)} without matching stopDirectory.`,
+			);
+		}
+
+		yield currentDirectory;
+
+		if (matched) {
+			return;
+		}
+
+		currentDirectory = parentDirectory;
+	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export interface FormatlyOptions {
+export interface FormatlyOptions extends ResolveFormatterOptions {
 	cwd?: string;
 
 	/**
@@ -50,3 +50,13 @@ export interface FormatterRunnerOptions {
 	cwd: string;
 	patterns: string[];
 }
+
+export interface ResolveFormatterOptions {
+	/**
+	 * Directory to stop searching parent directories for a config file at.
+	 * If not provided, only the working directory is searched.
+	 */
+	stopDirectory?: StopDirectory;
+}
+
+export type StopDirectory = ((currentDirectory: string) => boolean) | string;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #54
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an opt-in `stopDirectory` option that searches parent directories for a formatter config file.

Following the discussion on the issue, this is off by default: with no `stopDirectory`, `resolveFormatter` reads only `cwd`, exactly as before. Passing one walks upward from `cwd`, stopping once it has read the matching directory.

```ts
await resolveFormatter("path/to/project", {
	stopDirectory: "path/",
});

await resolveFormatter("path/to/project", {
	stopDirectory: (currentDirectory) =>
		existsSync(path.join(currentDirectory, ".git")),
});
```

Reaching the file system root without matching `stopDirectory` throws. That deliberately fails loudly rather than silently walking to `/`.

🧼 