### PR TITLE
feat: add order option to prefer formatters during detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Parameters:
 2. `options: FormatlyOptions` _(optional)_:
    - `cwd: string` _(optional)_: working directory, if not `"."`
    - `formatter: FormatterName` _(optional)_: explicit formatter to use instead of detecting one, supports `"biome"`, `"deno"`, `"dprint"`, and `"prettier"`
+   - `order: FormatterName[]` _(optional)_: formatters to detect first, in order, as used by [`resolveFormatter`](#resolveformatter)
    - `stopDirectory: StopDirectory` _(optional)_: directory to stop searching parent directories for a config file at, as used by [`resolveFormatter`](#resolveformatter)
 
 Resolves with a `FormatlyReport`, which is either:
@@ -132,6 +133,7 @@ Parameters:
 
 1. `cwd: string` _(optional)_: working directory, if not `"."`
 2. `options: ResolveFormatterOptions` _(optional)_:
+   - `order: FormatterName[]` _(optional)_: formatters to detect first, in order
    - `stopDirectory: StopDirectory` _(optional)_: directory to stop searching parent directories for a config file at, either a `string` path or a `(currentDirectory: string) => boolean` function
 
 By default, only the working directory is searched for a config file.
@@ -152,6 +154,24 @@ const formatter = await resolveFormatter("path/to/project", {
 });
 
 console.log(formatter);
+```
+
+By default, formatters are detected in their [documented order](#supported-formatters).
+Passing `order` tries the named formatters first, in the order given; any formatter not named is tried afterwards in the default order.
+Names listed more than once are only tried at their first position, and names that aren't supported formatters are ignored.
+
+For example, to detect Biome only if no other formatter matches:
+
+```ts
+import { resolveFormatter } from "formatly";
+
+const formatter = await resolveFormatter("path/to/project", {
+	order: ["deno", "dprint", "oxfmt", "prettier", "biome"],
+});
+
+if (formatter?.name === "biome") {
+	console.log("Only Biome was found, and it can't format Markdown.");
+}
 ```
 
 Resolves with either:

--- a/README.md
+++ b/README.md
@@ -158,20 +158,19 @@ console.log(formatter);
 
 By default, formatters are detected in their [documented order](#supported-formatters).
 Passing `order` tries the named formatters first, in the order given; any formatter not named is tried afterwards in the default order.
-Names listed more than once are only tried at their first position, and names that aren't supported formatters are ignored.
+Names listed more than once are only tried at their first position.
+Names that aren't supported formatters throw an error.
 
-For example, to detect Biome only if no other formatter matches:
+For example, to detect Biome before Prettier:
 
 ```ts
 import { resolveFormatter } from "formatly";
 
 const formatter = await resolveFormatter("path/to/project", {
-	order: ["deno", "dprint", "oxfmt", "prettier", "biome"],
+	order: ["biome", "prettier"],
 });
 
-if (formatter?.name === "biome") {
-	console.log("Only Biome was found, and it can't format Markdown.");
-}
+console.log(formatter);
 ```
 
 Resolves with either:

--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ console.log(formatter);
 
 By default, formatters are detected in their [documented order](#supported-formatters).
 Passing `order` tries the named formatters first, in the order given; any formatter not named is tried afterwards in the default order.
-Names listed more than once are only tried at their first position.
-Names that aren't supported formatters throw an error.
+Duplicate names, and names that aren't supported formatters, throw an error.
 
 For example, to detect Biome before Prettier:
 

--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { formatly } from "./formatly.js";
 import { formatters } from "./formatters/all.js";
+import { FormatterName } from "./types.js";
 
 const mockSpawn = vi.fn(() => ({
 	on: (
@@ -93,7 +94,20 @@ describe("formatly", () => {
 		await formatly(patterns, { stopDirectory });
 
 		expect(mockResolveFormatter).toHaveBeenCalledWith(process.cwd(), {
+			order: undefined,
 			stopDirectory,
+		});
+	});
+
+	it("passes order to resolveFormatter when provided", async () => {
+		const order: FormatterName[] = ["prettier"];
+		mockResolveFormatter.mockResolvedValueOnce(formatters[0]);
+
+		await formatly(patterns, { order });
+
+		expect(mockResolveFormatter).toHaveBeenCalledWith(process.cwd(), {
+			order,
+			stopDirectory: undefined,
 		});
 	});
 
@@ -115,6 +129,7 @@ describe("formatly", () => {
 		await formatly(patterns, { cwd });
 
 		expect(mockResolveFormatter).toHaveBeenCalledWith(cwd, {
+			order: undefined,
 			stopDirectory: undefined,
 		});
 

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -13,11 +13,11 @@ export async function formatly(
 		};
 	}
 
-	const { cwd = process.cwd(), stopDirectory } = options;
+	const { cwd = process.cwd(), order, stopDirectory } = options;
 
 	const formatter = options.formatter
 		? formatters.find((f) => f.name === options.formatter)
-		: await resolveFormatter(cwd, { stopDirectory });
+		: await resolveFormatter(cwd, { order, stopDirectory });
 
 	if (!formatter) {
 		return { message: "Could not detect a formatter.", ran: false };

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -183,16 +183,10 @@ describe("resolveFormatter", () => {
 			);
 		});
 
-		it("resolves with prettier when order lists prettier more than once", async () => {
-			mockReaddir.mockResolvedValueOnce(["biome.json", ".prettierrc"]);
-
-			const formatter = await resolveFormatter(".", {
-				order: ["prettier", "prettier"],
-			});
-
-			expect(formatter).toBe(
-				formatters.find((formatter) => formatter.name === "prettier"),
-			);
+		it("throws an error when order lists a formatter more than once", async () => {
+			await expect(
+				resolveFormatter(".", { order: ["prettier", "prettier"] }),
+			).rejects.toThrow("Duplicate formatter name in order: prettier.");
 		});
 
 		it("resolves with biome when order only lists formatters without a config file", async () => {

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -161,6 +161,74 @@ describe("resolveFormatter", () => {
 		});
 	});
 
+	describe("order", () => {
+		it("resolves with biome when order is not provided and multiple config files exist", async () => {
+			mockReaddir.mockResolvedValueOnce(["biome.json", ".prettierrc"]);
+
+			const formatter = await resolveFormatter();
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "biome"),
+			);
+		});
+
+		it("resolves with prettier when order prefers prettier over biome", async () => {
+			mockReaddir.mockResolvedValueOnce(["biome.json", ".prettierrc"]);
+
+			const formatter = await resolveFormatter(".", { order: ["prettier"] });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+		});
+
+		it("resolves with prettier when order lists prettier more than once", async () => {
+			mockReaddir.mockResolvedValueOnce(["biome.json", ".prettierrc"]);
+
+			const formatter = await resolveFormatter(".", {
+				order: ["prettier", "prettier"],
+			});
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+		});
+
+		it("resolves with biome when order only lists formatters without a config file", async () => {
+			mockReaddir.mockResolvedValueOnce(["biome.json"]);
+
+			const formatter = await resolveFormatter(".", { order: ["prettier"] });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "biome"),
+			);
+		});
+
+		it("resolves with prettier when order prefers prettier and both formatters exist in scripts", async () => {
+			mockReaddir.mockResolvedValueOnce([]);
+			mockFindPackage.mockResolvedValueOnce({
+				scripts: { format: "biome format", lint: "prettier" },
+			});
+
+			const formatter = await resolveFormatter(".", { order: ["prettier"] });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+		});
+
+		it("resolves with prettier when order prefers prettier and only a package key matches", async () => {
+			mockReaddir.mockResolvedValueOnce([]);
+			mockFindPackage.mockResolvedValueOnce({ prettier: {} });
+
+			const formatter = await resolveFormatter(".", { order: ["prettier"] });
+
+			expect(formatter).toBe(
+				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+		});
+	});
+
 	describe("from config file", () => {
 		it.each([
 			["biome", "biome.json", [".git", "biome.json", "src"]],

--- a/src/resolveFormatter.test.ts
+++ b/src/resolveFormatter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { formatters } from "./formatters/all.js";
 import { resolveFormatter } from "./resolveFormatter.js";
+import { FormatterName } from "./types.js";
 
 const mockReaddir = vi.fn();
 
@@ -214,6 +215,16 @@ describe("resolveFormatter", () => {
 
 			expect(formatter).toBe(
 				formatters.find((formatter) => formatter.name === "prettier"),
+			);
+		});
+
+		it("throws an error when order includes an unknown formatter name", async () => {
+			const order: string[] = ["unknown"];
+
+			await expect(
+				resolveFormatter(".", { order: order as FormatterName[] }),
+			).rejects.toThrow(
+				"Unknown formatter name in order: unknown. Known formatters are biome, deno, dprint, oxfmt, prettier.",
 			);
 		});
 

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -66,6 +66,8 @@ function createStopDirectoryMatcher(stopDirectory: StopDirectory) {
 }
 
 function orderFormatters(order: FormatterName[] = []) {
+	const seen = new Set<FormatterName>();
+
 	const preferred = order.map((name) => {
 		const formatter = formatters.find((formatter) => formatter.name === name);
 
@@ -74,6 +76,12 @@ function orderFormatters(order: FormatterName[] = []) {
 				`Unknown formatter name in order: ${name}. Known formatters are ${formatters.map((formatter) => formatter.name).join(", ")}.`,
 			);
 		}
+
+		if (seen.has(name)) {
+			throw new Error(`Duplicate formatter name in order: ${name}.`);
+		}
+
+		seen.add(name);
 
 		return formatter;
 	});

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -66,9 +66,17 @@ function createStopDirectoryMatcher(stopDirectory: StopDirectory) {
 }
 
 function orderFormatters(order: FormatterName[] = []) {
-	const preferred = order
-		.map((name) => formatters.find((formatter) => formatter.name === name))
-		.filter((formatter) => formatter !== undefined);
+	const preferred = order.map((name) => {
+		const formatter = formatters.find((formatter) => formatter.name === name);
+
+		if (!formatter) {
+			throw new Error(
+				`Unknown formatter name in order: ${name}. Known formatters are ${formatters.map((formatter) => formatter.name).join(", ")}.`,
+			);
+		}
+
+		return formatter;
+	});
 
 	return [...new Set([...preferred, ...formatters])];
 }

--- a/src/resolveFormatter.ts
+++ b/src/resolveFormatter.ts
@@ -3,17 +3,24 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 import { formatters } from "./formatters/all.js";
-import { Formatter, ResolveFormatterOptions, StopDirectory } from "./types.js";
+import {
+	Formatter,
+	FormatterName,
+	ResolveFormatterOptions,
+	StopDirectory,
+} from "./types.js";
 
 export async function resolveFormatter(
 	cwd = ".",
 	options: ResolveFormatterOptions = {},
 ): Promise<Formatter | undefined> {
+	const orderedFormatters = orderFormatters(options.order);
+
 	for (const directory of walkUpDirectories(cwd, options)) {
 		const children = await fs.readdir(directory);
 
-		for (const child of children) {
-			for (const formatter of formatters) {
+		for (const formatter of orderedFormatters) {
+			for (const child of children) {
 				if (formatter.testers.configFile.test(child)) {
 					return formatter;
 				}
@@ -28,15 +35,15 @@ export async function resolveFormatter(
 
 	const { scripts = {}, ...otherKeys } = packageData;
 
-	for (const script of Object.values(scripts as object)) {
-		for (const formatter of formatters) {
+	for (const formatter of orderedFormatters) {
+		for (const script of Object.values(scripts as object)) {
 			if (formatter.testers.script.test(script as string)) {
 				return formatter;
 			}
 		}
 	}
 
-	for (const formatter of formatters) {
+	for (const formatter of orderedFormatters) {
 		if (
 			"packageKey" in formatter.testers &&
 			formatter.testers.packageKey in otherKeys
@@ -56,6 +63,14 @@ function createStopDirectoryMatcher(stopDirectory: StopDirectory) {
 	const resolved = path.resolve(stopDirectory);
 
 	return (currentDirectory: string) => currentDirectory === resolved;
+}
+
+function orderFormatters(order: FormatterName[] = []) {
+	const preferred = order
+		.map((name) => formatters.find((formatter) => formatter.name === name))
+		.filter((formatter) => formatter !== undefined);
+
+	return [...new Set([...preferred, ...formatters])];
 }
 
 function* walkUpDirectories(

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,12 @@ export interface FormatterRunnerOptions {
 
 export interface ResolveFormatterOptions {
 	/**
+	 * Formatter names to detect in order, before any formatters not listed.
+	 * Unlisted formatters are then detected in their default order.
+	 */
+	order?: FormatterName[];
+
+	/**
 	 * Directory to stop searching parent directories for a config file at.
 	 * If not provided, only the working directory is searched.
 	 */


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #113
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`order: FormatterName[]` names formatters to try first, in the given order. Any formatter not named is tried afterwards in the default orde.

```ts
await resolveFormatter(cwd, {
	order: ["biome", "prettier"],
});
```

If a duplicate and/or unknown formatter name is provided, an error is thrown.

🧼 