### PR TITLE
feat: print detected formatter name in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npx formatly "src/**/*.ts"
 Once formatting finishes, the detected formatter's name is printed:
 
 ```plaintext
-Formatted with prettier! 🧼
+Formatted with prettier. 🧼
 ```
 
 ### Node.js API

--- a/README.md
+++ b/README.md
@@ -55,12 +55,6 @@ To match only `.ts` files in `src/`:
 npx formatly "src/**/*.ts"
 ```
 
-Once formatting finishes, the detected formatter's name is printed:
-
-```plaintext
-Formatted with prettier. 🧼
-```
-
 ### Node.js API
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It will then:
 
 1. Detect which [supported formatter](#supported-formatters) is configured in the repository
 2. Pass those glob patterns directly to the formatter
+3. Print which formatter was used
 
 For example, to match all directories and folders in the current directory:
 
@@ -51,6 +52,12 @@ To match only `.ts` files in `src/`:
 
 ```shell
 npx formatly "src/**/*.ts"
+```
+
+Once formatting finishes, the detected formatter's name is printed:
+
+```plaintext
+Formatted with prettier! 🧼
 ```
 
 ### Node.js API

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ It will then:
 
 1. Detect which [supported formatter](#supported-formatters) is configured in the repository
 2. Pass those glob patterns directly to the formatter
-3. Print which formatter was used
 
 For example, to match all directories and folders in the current directory:
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -12,20 +12,26 @@ vi.mock("./formatly.js", () => ({
 }));
 
 const mockError = vi.fn();
+const mockLog = vi.fn();
 
 const patterns = ["*"];
 
 describe("cli", () => {
 	beforeEach(() => {
 		console.error = mockError;
+		console.log = mockLog;
 	});
 
-	it("returns 0 without logging when formatly runs", async () => {
-		mockFormatly.mockResolvedValueOnce({ ran: true });
+	it("returns 0 and logs the formatter name when formatly runs", async () => {
+		mockFormatly.mockResolvedValueOnce({
+			formatter: { name: "prettier" },
+			ran: true,
+		});
 
 		const result = await cli(patterns);
 
 		expect(result).toBe(0);
+		expect(mockLog).toHaveBeenCalledWith("Formatted with prettier! 🧼");
 		expect(mockError).not.toHaveBeenCalled();
 	});
 
@@ -37,5 +43,6 @@ describe("cli", () => {
 
 		expect(result).toBe(1);
 		expect(mockError).toHaveBeenCalledWith(message);
+		expect(mockLog).not.toHaveBeenCalled();
 	});
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -31,7 +31,7 @@ describe("cli", () => {
 		const result = await cli(patterns);
 
 		expect(result).toBe(0);
-		expect(mockLog).toHaveBeenCalledWith("Formatted with prettier! 🧼");
+		expect(mockLog).toHaveBeenCalledWith("Formatted with prettier. 🧼");
 		expect(mockError).not.toHaveBeenCalled();
 	});
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ export async function cli(args: string[]) {
 	const result = await formatly(args);
 
 	if (result.ran) {
+		console.log(`Formatted with ${result.formatter.name}! 🧼`);
 		return 0;
 	}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ export async function cli(args: string[]) {
 	const result = await formatly(args);
 
 	if (result.ran) {
-		console.log(`Formatted with ${result.formatter.name}! 🧼`);
+		console.log(`Formatted with ${result.formatter.name}. 🧼`);
 		return 0;
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #123
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements way 1 from the issue: `npx formatly` now prints which formatter it used.

```plaintext
Formatted with prettier. 🧼
```

🧼 