### PR TITLE
fix: say formatter, not reporter, when detection fails

### DIFF
--- a/src/formatly.test.ts
+++ b/src/formatly.test.ts
@@ -47,7 +47,7 @@ describe("formatly", () => {
 		const report = await formatly(patterns);
 
 		expect(report).toEqual({
-			message: "Could not detect a reporter.",
+			message: "Could not detect a formatter.",
 			ran: false,
 		});
 		expect(mockSpawn).not.toHaveBeenCalled();

--- a/src/formatly.ts
+++ b/src/formatly.ts
@@ -20,7 +20,7 @@ export async function formatly(
 		: await resolveFormatter(cwd);
 
 	if (!formatter) {
-		return { message: "Could not detect a reporter.", ran: false };
+		return { message: "Could not detect a formatter.", ran: false };
 	}
 
 	return {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #124
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/formatly/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/formatly/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`"Could not detect a reporter."` -> `"Could not detect a formatter."`

🧼 